### PR TITLE
refactor: rename package name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bitwyre_ws_core"
+name = "darkpools_ws_core"
 version = "0.1.0"
 edition = "2018"
 publish = false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Websocket Core (Rust)
 
-![Build Status](https://github.com/bitwyre/websocket_core/workflows/Build/badge.svg)
+![Build Status](https://github.com/darkpools/websocket_core/workflows/Build/badge.svg)
 
 Websocket generic server library for:
 


### PR DESCRIPTION
This a package renaming to differentiate from the forking source.

Also, I highly suggest this is repo as the main dependencies for all our websocket repo.